### PR TITLE
feat: Support marshaling error interface

### DIFF
--- a/logrus_gcloud_formatter.go
+++ b/logrus_gcloud_formatter.go
@@ -36,7 +36,12 @@ func (f *LogrusGoogleCloudFormatter) Format(entry *logrus.Entry) ([]byte, error)
 	fields := make(logrus.Fields)
 
 	for k, v := range entry.Data {
-		fields[k] = v
+		switch v := v.(type) {
+		case error:
+			fields[k] = v.Error()
+		default:
+			fields[k] = v
+		}
 	}
 
 	fields["timestamp"] = entry.Time.Unix()


### PR DESCRIPTION
The field would be empty if using error interface.
Log the error message through Error method.